### PR TITLE
CVE-2025-27144: vendor: don't allow unbounded amounts of splits

### DIFF
--- a/vendor/github.com/go-jose/go-jose/v4/jwe.go
+++ b/vendor/github.com/go-jose/go-jose/v4/jwe.go
@@ -288,10 +288,11 @@ func ParseEncryptedCompact(
 	keyAlgorithms []KeyAlgorithm,
 	contentEncryption []ContentEncryption,
 ) (*JSONWebEncryption, error) {
-	parts := strings.Split(input, ".")
-	if len(parts) != 5 {
+	// Five parts is four separators
+	if strings.Count(input, ".") != 4 {
 		return nil, fmt.Errorf("go-jose/go-jose: compact JWE format must have five parts")
 	}
+	parts := strings.SplitN(input, ".", 5)
 
 	rawProtected, err := base64.RawURLEncoding.DecodeString(parts[0])
 	if err != nil {

--- a/vendor/github.com/go-jose/go-jose/v4/jws.go
+++ b/vendor/github.com/go-jose/go-jose/v4/jws.go
@@ -327,10 +327,11 @@ func parseSignedCompact(
 	payload []byte,
 	signatureAlgorithms []SignatureAlgorithm,
 ) (*JSONWebSignature, error) {
-	parts := strings.Split(input, ".")
-	if len(parts) != 3 {
+	// Three parts is two separators
+	if strings.Count(input, ".") != 2 {
 		return nil, fmt.Errorf("go-jose/go-jose: compact JWS format must have three parts")
 	}
+	parts := strings.SplitN(input, ".", 3)
 
 	if parts[1] != "" && payload != nil {
 		return nil, fmt.Errorf("go-jose/go-jose: payload is not detached")


### PR DESCRIPTION
In compact JWS/JWE, don't allow unbounded number of splits. Count to make sure there's the right number, then use SplitN.

Fixes CVE-2025-27144
Bugs: bsc#1237681

Cherry-picked from go-jose/go-jose@99b346c

